### PR TITLE
Human readable constraint strings

### DIFF
--- a/examples/GPA/createSpec.py
+++ b/examples/GPA/createSpec.py
@@ -9,7 +9,7 @@ from seldonian.models.models import LogisticRegressionModel
 if __name__ == '__main__':
     data_pth = "../../static/datasets/supervised/GPA/gpa_classification_dataset.csv"
     metadata_pth = "../../static/datasets/supervised/GPA/metadata_classification.json"
-    save_dir = '../../../interface_outputs/gpa_demographic_parity'
+    save_dir = '../../../interface_outputs/gpa_predictive_equality'
     os.makedirs(save_dir,exist_ok=True)
     # save_dir = '../../../interface_outputs/disparate_impact_fairlearn'
     # Load metadata
@@ -41,7 +41,9 @@ if __name__ == '__main__':
     # Define behavioral constraints
     # constraint_strs = ['0.8 - min((PR | [M])/(PR | [F]),(PR | [F])/(PR | [M]))'] 
     # constraint_strs = ['0.9 - min((PR | [M])/(PR),(PR)/(PR | [M]))'] 
-    constraint_strs = ['abs((PR | [M]) - (PR | [F])) - 0.2'] 
+    # constraint_strs = ['abs((PR | [M]) - (PR | [F])) - 0.2'] 
+    # constraint_strs = ['abs((FNR | [M]) - (FNR | [F])) + abs((FPR | [M]) - (FPR | [F])) - 0.35'] 
+    constraint_strs = ['abs((FPR | [M]) - (FPR | [F])) - 0.2'] 
     
     deltas = [0.05]
 

--- a/seldonian/RL/environments/gridworld.py
+++ b/seldonian/RL/environments/gridworld.py
@@ -3,6 +3,36 @@ from seldonian.RL.Env_Description.Env_Description import *
 
 class Gridworld(Environment):
     def __init__(self, size=3):
+        """ Square gridworld RL environment of arbitrary size.
+        
+        :param size: The number of grid cells on a side 
+        :type size: int
+
+        :ivar num_states: The number of distinct grid cells
+        :vartype num_states: int
+
+        :ivar env_description: an object for accessing attributes
+            of the environment
+        :vartype env_description: :py:class:`.Env_Description`
+
+        :ivar state: The current state 
+        :vartype state: int
+
+        :ivar terminal_state: Whether the terminal state is occupied
+        :vartype terminal_state: bool
+
+        :ivar time: The current timestep
+        :vartype time: int
+
+        :ivar max_time: Maximum allowed timestep
+        :vartype max_time: int
+
+        :ivar vis: Whether to print state when transitioning states
+        :vartype vis: bool
+
+        :ivar gamma: The discount factor in calculating the expected return
+        :vartype gamma: float
+        """
         self.size = size
         self.num_states = size*size
         self.env_description = self.create_env_description(self.num_states)

--- a/seldonian/models/models.py
+++ b/seldonian/models/models.py
@@ -287,17 +287,42 @@ class SquashedLinearRegressionModel(LinearRegressionModel):
 		:rtype: float
 		"""
 		n = len(X)
+		print(n)
 		prediction = self.predict(theta,X,Y) # vector of values
 		res = pow(prediction-Y,2)
 		return res
 
 	def gradient_sample_Squashed_Squared_Error(self,theta,X,Y):
 		n = len(X)
+		Y_min,Y_max = min(Y),max(Y)
+		Y_hat_min = (3*Y_min - Y_max)/2
+		Y_hat_max =(3*Y_max - Y_min)/2
+		c1 = Y_hat_max - Y_hat_min
+		c2 = -Y_hat_min
 		# prediction = sigma(Xw)
-		prediction = self.predict(theta,X,Y) # vector of values
-		err = prediction-Y
+		Y_hat = self.predict(theta,X,Y) # vector of values
+		Y_hat_old = np.dot(X,theta)
+		sig = self._sigmoid(Y_hat_old)
+
+		# print(X[0])
+		# s = 0
+		# for i in range(len(X)):
+		# 	term1=Y[i] - (c1*sig[i]-c2)
+		# 	term2=-c1*sig[i]*(1-sig[i])*X[i]
+		# 	s+=term1*term2
+
+		term1=Y - (c1*sig-c2)
+		term2=-c1*sig*(1-sig)*X[:,0]
+
+		# print(term1.shape)
+		# print(term2.shape)
+		# arg = term1*term2
+		# # print(arg.shape)
+		s = sum(term1*term2)
+		# # print(s.shape)
+		# s = sum(term1*term2)
 		# return 2/n*np.dot(err,prediction)*np.dot(1-prediction,X)
-		return 2/n*np.dot(err,prediction)*np.dot(1-prediction,X)
+		return -2/n*s
 
 	def _sigmoid(self,X):
 		return 1/(1+np.exp(X))

--- a/seldonian/parse_tree/nodes.py
+++ b/seldonian/parse_tree/nodes.py
@@ -804,8 +804,11 @@ class CVARSQEBaseNode(BaseNode):
 		
 		squared_errors = model.vector_Squashed_Squared_Error(theta,X,y)
 		# squared_errors_nosquash = pow(y_hats-y,2)
-		# import matplotlib.pyplot as plt
-		# fig = plt.figure()
+		import matplotlib.pyplot as plt
+		fig = plt.figure()
+		# plt.hist(squared_errors)
+		# y_hat = model.predict(theta,X,y)
+		# # plt.scatter(range(len(y)),y-y_hat)
 		# plt.hist(squared_errors)
 		# plt.show()
 		# input("Wait")
@@ -814,6 +817,8 @@ class CVARSQEBaseNode(BaseNode):
 		# or vice versa. Either way result would be y_max**2
 		a=min_squared_error
 		b=max_squared_error
+		print(a,b)
+		input("Wait")
 		# Need to sort them to get Z1, ..., Zn
 		sorted_squared_errors = sorted(squared_errors)
 

--- a/seldonian/parse_tree/parse_tree.py
+++ b/seldonian/parse_tree/parse_tree.py
@@ -162,27 +162,35 @@ class ParseTree(object):
 		:return: String for g
 		:rtype: str
 		"""
-		for c in ['<','>','=']:
-			if c in s:
-				raise RuntimeError(
-					"Not a valid constraint string "
-					f"because we found the character: '{c}', "
-					"which is not allowed")
-
 		if '<=' in s:
 			assert s.count("<=") == 1
 			assert s.count(">=") == 0
 			start_index = s.index("<=")
+			LHS = s[0:start_index].strip()
 			RHS = s[start_index+2:].strip()
-			new_s = s[0:start_index].strip() + f'-({RHS})' 
+			if RHS == '0':
+				new_s = LHS
+			else:
+				new_s = LHS + f'-({RHS})' 
 		elif '>=' in s:
 			assert s.count(">=") == 1
 			assert s.count("<=") == 0
 			start_index = s.index(">=")
 			LHS = s[:start_index].strip()
-			new_s = s[start_index+2:].strip() + f'-({LHS})'
+			RHS = s[start_index+2:].strip()
+			if LHS == 0:
+				new_s = RHS
+			else:
+				new_s = RHS + f'-({LHS})'
 		else:
 			new_s = s
+
+		# Validate that new string does not have bad symbols in it
+		for c in ['<','>','=']:
+			if c in new_s:
+				raise NotImplementedError("Error parsing your expression."
+				" An operator was used which we do not support: "
+				f"{c}")
 		return new_s
 		
 	def _ast_tree_helper(self,ast_node):

--- a/seldonian/parse_tree/parse_tree.py
+++ b/seldonian/parse_tree/parse_tree.py
@@ -178,7 +178,7 @@ class ParseTree(object):
 			start_index = s.index(">=")
 			LHS = s[:start_index].strip()
 			RHS = s[start_index+2:].strip()
-			if LHS == 0:
+			if LHS == '0':
 				new_s = RHS
 			else:
 				new_s = RHS + f'-({LHS})'

--- a/seldonian/spec.py
+++ b/seldonian/spec.py
@@ -305,7 +305,9 @@ class RLSpec(Spec):
 		regularization_hyperparams={},
 		normalize_returns=False
 		):
-		super().__init__(dataset,model_class,
+		super().__init__(
+			dataset,
+			model_class,
 			frac_data_in_safety,
 			primary_objective,
 			initial_solution_fn,

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ setuptools.setup(
     install_requires=[
         "autograd>=1.4",
         "cma>=3.2.2",
-        "Flask>=2.1.2",
-        "Flask_WTF>=1.0.1",
         "graphviz>=0.19.1",
         "gym>=0.23.1",
         "matplotlib==3.5.1", 
@@ -36,7 +34,6 @@ setuptools.setup(
         "scipy>=1.7.3",
         "tqdm>=4.64.0",
         "Werkzeug==2.1.2",
-        "WTForms==3.0.1",
     ],
     packages=setuptools.find_packages(),
     python_requires=">=3.8",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def synthetic_dataset(generate_data):
     def generate_dataset(constraint_strs,deltas):
         rseed=0
         np.random.seed(rseed) 
-        numPoints=1000
+        numPoints=5000
         columns=['feature1','label']
         model_class = LinearRegressionModel
         X,Y = generate_data(

--- a/tests/test_parse_tree.py
+++ b/tests/test_parse_tree.py
@@ -452,8 +452,38 @@ def test_parse_tree_with_inequalities():
 	pt_lte0.build_tree(
 		constraint_str=constraint_str_lte0,
 		delta_weight_method='equal')
-	graph = pt_lte0.make_viz(constraint_str_lte0)
-	graph.view()
+
+	assert pt_lte0.n_nodes == 5
+	assert pt_lte0.n_base_nodes == 2
+	assert len(pt_lte0.base_node_dict) == 2
+	assert isinstance(pt_lte0.root,InternalNode)
+	assert pt_lte0.root.name == 'sub'
+	assert pt_lte0.root.left.name == 'FPR'
+	assert pt_lte0.root.right.name == 'add'
+	assert pt_lte0.root.right.left.name == '0.5'
+	assert pt_lte0.root.right.left.value == 0.5
+	assert pt_lte0.root.right.right.name == 'PR | [M]'
+	
+	# >= 0
+	constraint_str_gte0 = '0 >= FPR - (0.5 + (PR | [M]))'
+	pt_gte0 = ParseTree(delta=0.05,regime='supervised',
+			sub_regime='classification',columns=['M'])
+
+	# Fill out tree
+	pt_gte0.build_tree(
+		constraint_str=constraint_str_gte0,
+		delta_weight_method='equal')
+
+	assert pt_gte0.n_nodes == 5
+	assert pt_gte0.n_base_nodes == 2
+	assert len(pt_gte0.base_node_dict) == 2
+	assert isinstance(pt_gte0.root,InternalNode)
+	assert pt_gte0.root.name == 'sub'
+	assert pt_gte0.root.left.name == 'FPR'
+	assert pt_gte0.root.right.name == 'add'
+	assert pt_gte0.root.right.left.name == '0.5'
+	assert pt_gte0.root.right.left.value == 0.5
+	assert pt_gte0.root.right.right.name == 'PR | [M]'
 
 
 def test_math_functions():

--- a/tests/test_seldonian_algorithm.py
+++ b/tests/test_seldonian_algorithm.py
@@ -359,7 +359,7 @@ def test_cvar_custom_base_node(synthetic_dataset):
 		deltas=deltas)
 	
 	spec.model_class = SquashedLinearRegressionModel
-	spec.use_builtin_primary_gradient_fn = False
+	spec.use_builtin_primary_gradient_fn = True
 	spec.primary_objective = SquashedLinearRegressionModel().sample_Squashed_Squared_Error
 	# Run seldonian algorithm
 	SA = SeldonianAlgorithm(spec)


### PR DESCRIPTION
Adds the ability to use "<=" and ">=" in constraint strings. Will resolve the string so that it is "{constraint_str} <= 0" in a preprocessing step so that the original parse tree parser can be used. 