### PR TITLE
specify environment object in hyperparameter dictionary

### DIFF
--- a/seldonian/RL/RL_runner.py
+++ b/seldonian/RL/RL_runner.py
@@ -52,7 +52,7 @@ def run_trial(hyperparameter_and_setting_dict,
         # print(model_params)
         agent.set_new_params(model_params)
 
-    env = create_env(hyperparameter_and_setting_dict)
+    env = hyperparameter_and_setting_dict["env"]
     if hyperparameter_and_setting_dict["vis"]:
         env.start_visualizing()
 
@@ -130,7 +130,7 @@ def run_episode_from_dict(hyperparameter_and_setting_dict,model_params=None):
     :return: RL Episode
     :rtype: :py:class:`.Episode`
     """
-    env = create_env(hyperparameter_and_setting_dict)
+    env = hyperparameter_and_setting_dict["env"]
     env_desc = env.get_env_description()
     agent = create_agent(hyperparameter_and_setting_dict)
     if model_params is not None:
@@ -171,8 +171,8 @@ def create_agent(hyperparameter_and_setting_dict):
     :return: RL agent
     :rtype: :py:class:`.Agents.Agent`
     """
-    sample_env = create_env(hyperparameter_and_setting_dict)
-    env_desc = sample_env.get_env_description()
+    env = hyperparameter_and_setting_dict["env"]
+    env_desc = env.get_env_description()
     agent_type = hyperparameter_and_setting_dict["agent"]
     if agent_type == "discrete_random":
         return Discrete_Random_Agent(env_desc)
@@ -184,25 +184,3 @@ def create_agent(hyperparameter_and_setting_dict):
         return Keyboard_gridworld(env_desc)
     else:
         raise Exception(f"unknown agent type {agent_type}")
-
-def create_env(hyperparameter_and_setting_dict):
-    """ Create an environment from a dictionary specification
-    
-    :param hyperparameter_and_setting_dict: Specifies the
-        environment, agent, number of episodes per trial,
-        and number of trials
-
-    :return: RL environment
-    :rtype: :py:class:`.environments.Environment`
-    """
-    env_type = hyperparameter_and_setting_dict["env"]
-    if env_type == "gridworld":
-        return Gridworld()
-    elif env_type == "mountaincar":
-        return Mountaincar()
-    elif env_type == "n_step_mountaincar":
-        return N_step_mountaincar()
-    elif env_type == "simglucose":
-        return Simglucose()
-    else:
-        raise Exception(f"unknown agent type {env_type}")

--- a/seldonian/RL/generate_gridworld_episodes.py
+++ b/seldonian/RL/generate_gridworld_episodes.py
@@ -6,13 +6,14 @@ from seldonian.utils.RL_utils import *
 from seldonian.utils.io_utils import save_pickle
 from seldonian.utils.stats_utils import weighted_sum_gamma
 from seldonian.spec import createRLSpec
+from seldonian.RL.environments.gridworld import Gridworld
 
 def main():
     """ Run a trial of episodes and save to disk
     """  
-    n_episodes = 5000
+    n_episodes = 1000
     the_dict = {}
-    the_dict["env"] = "gridworld"
+    the_dict["env"] = Gridworld()
     the_dict["agent"] = "Parameterized_non_learning_softmax_agent"
     the_dict["num_episodes"] = n_episodes
     the_dict["vis"] = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,7 +158,6 @@ def simulated_regression_dataset_aslists():
     
     return generate_dataset
 
-
 @pytest.fixture
 def simulated_regression_dataset():
 

--- a/tests/test_RL.py
+++ b/tests/test_RL.py
@@ -2,7 +2,8 @@ import pytest
 from seldonian.RL.Agents.Function_Approximators.Table import *
 from seldonian.RL.Agents.Policies.Policy import *
 from seldonian.RL.Agents.Policies.Softmax import *
-from seldonian.RL.environments.mountaincar import *
+from seldonian.RL.environments.n_step_mountaincar import N_step_mountaincar
+from seldonian.RL.environments.gridworld import Gridworld
 from seldonian.RL.Agents.Parameterized_non_learning_softmax_agent import *
 from seldonian.RL.Agents.Discrete_Random_Agent import *
 from seldonian.RL.RL_runner import run_trial
@@ -207,14 +208,14 @@ def test_generate_gridworld_episodes():
     """ Test that we can generate proper episodes for gridworld
     with the behavior policy (uniform random). """
     hyperparam_and_setting_dict = {}
-    hyperparam_and_setting_dict["env"] = "gridworld"
+    hyperparam_and_setting_dict["env"] = Gridworld()
     hyperparam_and_setting_dict["agent"] = "Parameterized_non_learning_softmax_agent"
-    hyperparam_and_setting_dict["num_episodes"] = 100
+    hyperparam_and_setting_dict["num_episodes"] = 10
     hyperparam_and_setting_dict["vis"] = False
 
     episodes, agent = run_trial(hyperparam_and_setting_dict)
 
-    assert len(episodes) == 100
+    assert len(episodes) == 10
     first_episode = episodes[0]
     observations = first_episode.observations
     actions = first_episode.actions
@@ -234,23 +235,23 @@ def test_generate_gridworld_episodes():
     assert all([pi == 0.25 for pi in pis])
 
     dataset = RLDataSet(episodes=episodes,meta_information=['O','A','R','pi'])
-    assert len(dataset.episodes) == 100
+    assert len(dataset.episodes) == 10
 
 def test_generate_n_step_mountaincar_episodes():
     """ Test that we can generate proper episodes for n_step_mountaincar
     with the behavior policy (uniform random). """
     hyperparam_and_setting_dict = {}
-    hyperparam_and_setting_dict["env"] = "n_step_mountaincar"
+    hyperparam_and_setting_dict["env"] = N_step_mountaincar()
     hyperparam_and_setting_dict["agent"] = "Parameterized_non_learning_softmax_agent"
     hyperparam_and_setting_dict["basis"] = "Fourier"
     hyperparam_and_setting_dict["order"] = 2
     hyperparam_and_setting_dict["max_coupled_vars"] = -1
-    hyperparam_and_setting_dict["num_episodes"] = 100
+    hyperparam_and_setting_dict["num_episodes"] = 10
     hyperparam_and_setting_dict["vis"] = False
 
     episodes, agent = run_trial(hyperparam_and_setting_dict)
 
-    assert len(episodes) == 100
+    assert len(episodes) == 10
     first_episode = episodes[0]
     observations = first_episode.observations
     actions = first_episode.actions
@@ -270,4 +271,4 @@ def test_generate_n_step_mountaincar_episodes():
     assert all([pi == 1/3. for pi in pis])
 
     dataset = RLDataSet(episodes=episodes,meta_information=['O','A','R','pi'])
-    assert len(dataset.episodes) == 100
+    assert len(dataset.episodes) == 10


### PR DESCRIPTION
This PR changes how the RL environment is specified in the `hyperparameter_and_settings_dict`. Previously, users would specify a string name for their environment, which the engine would internally attribute to an environment class. This required the engine to know about every environment that could be used. This limited the ability to use external environment classes, i.e., those not defined within the Engine itself. In order to accommodate externally-defined environment classes, this PR changes the meaning of the `env` key to the `hyperparameter_and_settings_dict` used in RL for generating episodes. Now, this key must contain an instance of the environment class the user wants to use. This environment class can be externally defined (as long as it still inherits from the `seldonian.RL.environments.Environment.Environment` base class), or it can be one of the internal environments coded into the engine, such as `seldonian.RL.environments.gridworld.Gridworld`. For example, this is now the correct syntax:

``` Python
from seldonian.RL.environments.gridworld import Gridworld
hyperparameter_and_settings_dict = {}
hyperparameter_and_settings_dict["env"] = Gridworld()
...
```