### PR TITLE
Safety batching

### DIFF
--- a/examples/GPA_tutorial/createSpec.py
+++ b/examples/GPA_tutorial/createSpec.py
@@ -11,8 +11,8 @@ from seldonian.models import objectives
 if __name__ == '__main__':
     data_pth = "../../static/datasets/supervised/GPA/gpa_classification_dataset.csv"
     metadata_pth = "../../static/datasets/supervised/GPA/metadata_classification.json"
-    # save_base_dir = '../../../interface_outputs'
-    save_base_dir='.'
+    save_base_dir = '../../../interface_outputs'
+    # save_base_dir='.'
     # Load metadata
     regime='supervised_learning'
     sub_regime='classification'
@@ -27,10 +27,9 @@ if __name__ == '__main__':
     
     # Behavioral constraints
     deltas = [0.05]
-    # for constraint_name in ["disparate_impact",
-    #     "demographic_parity","equalized_odds",
-    #     "equal_opportunity","predictive_equality"]:
-    for constraint_name in ["disparate_impact"]:
+    for constraint_name in ["disparate_impact",
+        "demographic_parity","equalized_odds",
+        "equal_opportunity","predictive_equality"]:
         save_dir = os.path.join(save_base_dir,f'gpa_{constraint_name}')
         os.makedirs(save_dir,exist_ok=True)
         # Define behavioral constraints

--- a/examples/engine_tutorial/example.py
+++ b/examples/engine_tutorial/example.py
@@ -34,6 +34,7 @@ if __name__ == "__main__":
         model=model,
         parse_trees=parse_trees,
         sub_regime='regression',
+        batch_size_safety=100,
     )
 
     # 5. Run seldonian algorithm using the spec object

--- a/examples/tensorflow_mnist/example.py
+++ b/examples/tensorflow_mnist/example.py
@@ -1,0 +1,112 @@
+# tensorflow_mnist.py
+import autograd.numpy as np   # Thinly-wrapped version of Numpy
+
+from seldonian.spec import SupervisedSpec
+from seldonian.dataset import SupervisedDataSet
+from seldonian.utils.io_utils import load_pickle
+from seldonian.models.tensorflow_cnn import TensorFlowCNN
+from seldonian.models import objectives
+from seldonian.seldonian_algorithm import SeldonianAlgorithm
+from seldonian.parse_tree.parse_tree import (
+	make_parse_trees_from_constraints)
+
+import tensorflow as tf
+
+if __name__ == "__main__":
+	tf.random.set_seed(42)
+	regime='supervised_learning'
+	sub_regime='multiclass_classification'
+	mnist = tf.keras.datasets.mnist
+	(x_train, y_train), (x_test, y_test) = mnist.load_data()    
+	x_train=x_train.reshape(x_train.shape[0], x_train.shape[1], x_train.shape[2], 1)
+	x_train=(x_train / 255.0).astype('float32')
+	x_test = x_test.reshape(x_test.shape[0], x_test.shape[1], x_test.shape[2], 1)
+	x_test=(x_test/255.0).astype('float32')
+	# Combine x_train and x_test into a single feature array and take first N of them
+	N=70000
+	features = np.vstack([x_train,x_test])[0:N]
+	# Combine y_train and y_test into a single label array
+	labels = np.hstack([y_train,y_test])[0:N]
+	 
+	assert len(features) == N
+	assert len(labels) == N
+	frac_data_in_safety = 0.1
+
+	meta_information = {}
+	meta_information['feature_col_names'] = ['img']
+	meta_information['label_col_names'] = ['label']
+	meta_information['sensitive_col_names'] = []
+	meta_information['sub_regime'] = sub_regime
+
+	dataset = SupervisedDataSet(
+		features=features,
+		labels=labels,
+		sensitive_attrs=[],
+		num_datapoints=N,
+		meta_information=meta_information)
+
+	constraint_strs = ['ACC >= 0.9']
+	deltas = [0.05] 
+
+	parse_trees = make_parse_trees_from_constraints(
+		constraint_strs,deltas,regime=regime,
+		sub_regime=sub_regime)
+
+	model = TensorFlowCNN()
+
+	initial_solution_fn = model.get_initial_weights
+	# theta_file = '../../../notebooks/best_theta_mnist_tensorflow.pkl'
+	# best_theta = load_pickle(theta_file)
+	# print("loaded best theta:")
+	# print(best_theta)
+	# initial_solution_fn = lambda *args: initial_theta
+	
+	spec = SupervisedSpec(
+		dataset=dataset,
+		model=model,
+		parse_trees=parse_trees,
+		frac_data_in_safety=frac_data_in_safety,
+		primary_objective=objectives.multiclass_logistic_loss,
+		use_builtin_primary_gradient_fn=False,
+		sub_regime=sub_regime,
+		initial_solution_fn=initial_solution_fn,
+		optimization_technique='gradient_descent',
+		optimizer='adam',
+		optimization_hyperparams={
+			'lambda_init'   : np.array([0.5]),
+			'alpha_theta'   : 0.001,
+			'alpha_lamb'    : 0.01,
+			'beta_velocity' : 0.9,
+			'beta_rmsprop'  : 0.95,
+			'use_batches'   : True,
+			'batch_size'    : 150,
+			'n_epochs'      : 5,
+			'gradient_library': "autograd",
+			'hyper_search'  : None,
+			'verbose'       : True,
+		},
+	)
+	# save_pickle('./spec.pkl',spec)
+	SA = SeldonianAlgorithm(spec)
+	# initial_weights = initial_solution_fn(dataset,model)
+	# SA.initial_solution = best_theta
+	# print("random initial weights are:")
+	# print(initial_weights)
+	# model.update_model_params(initial_weights)
+
+	passed_safety,solution = SA.run(debug=True,write_cs_logfile=True)
+	# f_cs_best = SA.evaluate_primary_objective(branch='candidate_selection',theta=best_theta)
+	# passed_safety,solution = SA.run_safety_test(candidate_solution=best_theta,debug=True)
+	# f_st_best = SA.evaluate_primary_objective(branch='safety_test',theta=best_theta)
+	# print("f_st_best:")
+	# print(f_st_best)
+	# print("f_cs_best,f_st_best")
+	# print(f_cs_best,f_st_best)
+	# if passed_safety:
+	# 	print("Passed safety test.")
+	# else:
+	# 	print("Failed safety test")
+	# st_primary_objective = SA.evaluate_primary_objective(theta=solution,
+	# 	branch='safety_test')
+	# print("Primary objective evaluated on safety test:")
+	# print(st_primary_objective)

--- a/examples/tensorflow_mnist/example.py
+++ b/examples/tensorflow_mnist/example.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 	 
 	assert len(features) == N
 	assert len(labels) == N
-	frac_data_in_safety = 0.1
+	frac_data_in_safety = 0.5
 
 	meta_information = {}
 	meta_information['feature_col_names'] = ['img']
@@ -55,12 +55,12 @@ if __name__ == "__main__":
 	model = TensorFlowCNN()
 
 	initial_solution_fn = model.get_initial_weights
-	# theta_file = '../../../notebooks/best_theta_mnist_tensorflow.pkl'
-	# best_theta = load_pickle(theta_file)
+	theta_file = '../../../notebooks/best_theta_mnist_tensorflow.pkl'
+	best_theta = load_pickle(theta_file)
 	# print("loaded best theta:")
 	# print(best_theta)
 	# initial_solution_fn = lambda *args: initial_theta
-	
+	batch_size_safety=5000
 	spec = SupervisedSpec(
 		dataset=dataset,
 		model=model,
@@ -85,6 +85,7 @@ if __name__ == "__main__":
 			'hyper_search'  : None,
 			'verbose'       : True,
 		},
+		batch_size_safety=batch_size_safety
 	)
 	# save_pickle('./spec.pkl',spec)
 	SA = SeldonianAlgorithm(spec)
@@ -94,9 +95,10 @@ if __name__ == "__main__":
 	# print(initial_weights)
 	# model.update_model_params(initial_weights)
 
-	passed_safety,solution = SA.run(debug=True,write_cs_logfile=True)
+	# passed_safety,solution = SA.run(debug=True,write_cs_logfile=True)
 	# f_cs_best = SA.evaluate_primary_objective(branch='candidate_selection',theta=best_theta)
-	# passed_safety,solution = SA.run_safety_test(candidate_solution=best_theta,debug=True)
+	passed_safety,solution = SA.run_safety_test(
+		candidate_solution=best_theta,batch_size_safety=batch_size_safety,debug=True)
 	# f_st_best = SA.evaluate_primary_objective(branch='safety_test',theta=best_theta)
 	# print("f_st_best:")
 	# print(f_st_best)

--- a/seldonian/candidate_selection/candidate_selection.py
+++ b/seldonian/candidate_selection/candidate_selection.py
@@ -391,9 +391,8 @@ class CandidateSelection(object):
 			# Want to maximize the importance weight so minimize negative importance weight
 			# Adding regularization term so that large thetas make this less negative
 			# and therefore worse 
-			data_dict = {'episodes':self.batch_dataset.episodes}
 			result = -1.0*self.primary_objective(self.model,theta,
-				data_dict)
+				self.batch_dataset.episodes)
 
 		if hasattr(self,'reg_coef'):
 			# reg_term = self.reg_coef*np.linalg.norm(theta)

--- a/seldonian/models/models.py
+++ b/seldonian/models/models.py
@@ -8,7 +8,6 @@ from functools import partial, lru_cache
 
 from seldonian.utils.stats_utils import softmax
 
-import torch
 
 class SeldonianModel(object):
 	def __init__(self):

--- a/seldonian/models/tensorflow_cnn.py
+++ b/seldonian/models/tensorflow_cnn.py
@@ -1,0 +1,37 @@
+# tensorflow_cnn.py
+
+from seldonian.models.tensorflow_model import SupervisedTensorFlowBaseModel
+
+import tensorflow as tf
+
+class TensorFlowCNN(SupervisedTensorFlowBaseModel):
+	def __init__(self,**kwargs):
+		""" Base class for Supervised learning Seldonian
+		models implemented in TensorFlow
+		 
+		"""
+		super().__init__()
+
+	def create_model(self,**kwargs):
+		""" Create the TensorFlow model and return it
+		"""
+		num_classes = 10
+		input_shape = (28, 28, 1)
+		cnn = tf.keras.models.Sequential([
+			tf.keras.layers.Conv2D(32, (5,5), padding='same', activation='relu',
+				input_shape=input_shape),
+			tf.keras.layers.Conv2D(32, (5,5), padding='same', activation='relu'),
+			tf.keras.layers.MaxPool2D(),
+			tf.keras.layers.Dropout(0.25),
+			tf.keras.layers.Conv2D(64, (3,3), padding='same', activation='relu'),
+			tf.keras.layers.Conv2D(64, (3,3), padding='same', activation='relu'),
+			tf.keras.layers.MaxPool2D(strides=(2,2)),
+			tf.keras.layers.Dropout(0.25),
+			tf.keras.layers.Flatten(),
+			tf.keras.layers.Dense(128, activation='relu'),
+			tf.keras.layers.Dropout(0.5),
+			tf.keras.layers.Dense(num_classes, activation='softmax')
+		])	
+		cnn.build(input_shape=input_shape)
+		return cnn	
+

--- a/seldonian/models/tensorflow_model.py
+++ b/seldonian/models/tensorflow_model.py
@@ -1,0 +1,173 @@
+# tensorflow_model.py
+
+import autograd.numpy as np   # Thinly-wrapped version of Numpy
+from autograd.extend import primitive, defvjp
+from seldonian.models.models import SupervisedModel
+
+import tensorflow as tf
+
+
+@primitive
+def tf_predict(theta,X,model,**kwargs):
+	""" Do a forward pass through the TensorFlow model.
+	Must convert back to numpy array before returning 
+
+	:param theta: model weights
+	:type theta: numpy ndarray
+	:param X: model features
+	:type X: numpy ndarray
+
+	:param model: An instance of a class inheriting from
+		SupervisedTensorFlowBaseModel 
+
+	:return pred_numpy: model predictions 
+	:rtype pred_numpy: numpy ndarray same shape as labels
+	"""
+	# First update model weights
+	model.update_model_params(theta,**kwargs)
+	# Do the forward pass
+	pred = model.forward_pass(X,**kwargs)
+	# set the predictions attribute of the model
+	model.predictions = pred
+	# Convert predictions into a numpy array
+	pred_numpy = pred.numpy()
+	return pred_numpy
+
+def tf_predict_vjp(ans,theta,X,model):
+	""" Do a backward pass through the TensorFlow model,
+	obtaining the Jacobian d pred / dtheta. 
+	Must convert back to numpy array before returning 
+
+	:param ans: The result from tf_predict
+	:type ans: numpy ndarray
+	:param theta: model weights
+	:type theta: numpy ndarray
+	:param X: model features
+	:type X: numpy ndarray
+
+	:param model: An instance of a class inheriting from
+		SupervisedTensorFlowBaseModel 
+
+	:return fn: A function representing the vector Jacobian operator
+	"""
+	def fn(v):
+		# v is a vector of shape ans, the return value of mypredict()
+		# return a 1D array [dF_i/dtheta[0],dF_i/dtheta[1],dF_i/dtheta[2]],
+		# where i is the data row index
+		# print("v:")
+		# print(v)
+		# input("next")
+		dpred_dtheta = model.backward_pass(v)
+		return dpred_dtheta
+	return fn
+
+# Link the predict function with its gradient,
+# telling autograd not to look inside either of these functions
+defvjp(tf_predict,tf_predict_vjp)
+
+class SupervisedTensorFlowBaseModel(SupervisedModel):
+	def __init__(self,**kwargs):
+		""" Base class for Supervised learning Seldonian
+		models implemented in TensorFlow
+		 
+		:param device: The PyTorch device string indicating the
+			hardware on which to run the model,
+			e.g. "cpu", "cuda", "mps".
+		:type device: str
+		"""
+		super().__init__()
+		self.tensorflow_model = self.create_model(**kwargs)
+		self.param_sizes = self.get_param_sizes()
+		self.weights_updated = False
+
+	def predict(self,theta,X,**kwargs):
+		""" Do a forward pass through the PyTorch model.
+		Must convert back to numpy array before returning 
+
+		:param theta: model weights
+		:type theta: numpy ndarray
+
+		:param X: model features
+		:type X: numpy ndarray
+
+		:return pred_numpy: model predictions 
+		:rtype pred_numpy: numpy ndarray same shape as labels
+		"""
+		return tf_predict(theta,X,self)
+
+	def get_initial_weights(self,*args):
+		""" Return initial weights as a flattened 1D array
+		Also return the number of elements in each model parameter """
+		layer_params_list = []
+		for param in self.tensorflow_model.trainable_weights:
+			layer_params_list.append(param.numpy().flatten())
+		return np.concatenate(layer_params_list)
+
+	def get_param_sizes(self):
+		""" Get the sizes (shapes) of each of the model parameters
+		"""
+		param_sizes = []
+		for param in self.tensorflow_model.trainable_weights:
+			param_sizes.append(np.prod(param.shape))
+		return param_sizes
+
+	def update_model_params(self,theta,**kwargs):
+		""" Update all model parameters using theta,
+		which must be reshaped
+
+		:param theta: model weights
+		:type theta: numpy ndarray
+		"""
+		# Update model parameters using flattened array
+		i = 0
+		startindex = 0
+		for param in self.tensorflow_model.trainable_weights:
+			nparams = self.param_sizes[i]
+			param_shape = param.shape
+			theta_numpy = theta[startindex:startindex+nparams]
+			theta_tf_flat = tf.convert_to_tensor(theta_numpy)
+			theta_tf = tf.reshape(theta_tf_flat,param_shape)
+			param.assign(theta_tf)
+			i+=1
+			startindex+=nparams
+		return
+
+	def forward_pass(self,X,**kwargs):
+		""" Do a forward pass through the TensorFlow model and return the 
+		model outputs (predicted labels). The outputs should be the same shape 
+		as the true labels
+	
+		:param X: model features
+		:type X: numpy ndarray
+
+		:return: predictions
+		:rtype: torch.Tensor
+		"""
+		with tf.GradientTape(persistent=True) as tape:
+			X_tf = tf.convert_to_tensor(X)
+			predictions = self.tensorflow_model(X_tf)
+		self.tape = tape
+		return predictions
+
+	def backward_pass(self,v):
+		""" Do a backward pass through the TensorFlow model and return the
+		(vector) gradient of the model with respect to theta as a numpy ndarray
+
+		:param external_grad: The gradient of the model with respect to itself
+			see: https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html#differentiation-in-autograd
+			for more details
+		:type external_grad: torch.Tensor 
+		"""
+		grad_params_list = []
+		grads = self.tape.gradient(self.predictions, 
+			self.tensorflow_model.trainable_weights,output_gradients=v)
+		for grad in grads:
+			grad_numpy = grad.numpy()
+			grad_params_list.append(grad_numpy.flatten())
+		return np.concatenate(grad_params_list)
+
+	def create_model(self,**kwargs):
+		""" Create the TensorFlow model and return it
+		"""
+		raise NotImplementedError("Implement this method in child class")
+

--- a/seldonian/optimizers/gradient_descent.py
+++ b/seldonian/optimizers/gradient_descent.py
@@ -139,7 +139,10 @@ def gradient_descent_adam(
     # Start gradient descent
     gd_index = 0
     if verbose:
-        print(f"Have {n_epochs} epochs and {n_batches} batches of size {batch_size}\n")
+        n_iters_tot = n_epochs*n_batches
+        print(
+            f"Have {n_epochs} epochs and {n_batches} batches of size {batch_size} "
+            f"for a total of {n_iters_tot} iterations")
     for epoch in range(n_epochs):
         for batch_index in range(n_batches):
             if verbose:
@@ -175,7 +178,7 @@ def gradient_descent_adam(
             # at current values of theta and lambda
             grad_primary_theta_val = grad_primary_theta(theta)
             gu_theta_vec = grad_upper_bound_theta(theta)
-            
+
             grad_secondary_theta_val_vec = gu_theta_vec * lamb[:, None] ## to multiply each row of gu_theta_vec by elements of lamb
             gradient_theta = grad_primary_theta_val + np.sum(grad_secondary_theta_val_vec,axis=0)
             

--- a/seldonian/parse_tree/nodes.py
+++ b/seldonian/parse_tree/nodes.py
@@ -134,13 +134,9 @@ class BaseNode(Node):
         not the bound.
         """ 
     
-        model = kwargs['model']
-        theta = kwargs['theta']
-        data_dict = kwargs['data_dict']
-        value = evaluate_statistic(model,
+        value = evaluate_statistic(
             statistic_name=self.measure_function_name,
-            theta=theta,
-            data_dict=data_dict)
+            **kwargs)
         return value
 
     def mask_data(self,

--- a/seldonian/parse_tree/parse_tree.py
+++ b/seldonian/parse_tree/parse_tree.py
@@ -484,7 +484,6 @@ class ParseTree(object):
 
 		return node_class,node_kwargs
 		
-
 	def assign_deltas(self,weight_method='equal',
 		**kwargs):
 		""" 

--- a/seldonian/seldonian_algorithm.py
+++ b/seldonian/seldonian_algorithm.py
@@ -248,11 +248,14 @@ class SeldonianAlgorithm():
 			return passed_safety,solution
 			
 		# Safety test
+		batch_size_safety = self.spec.batch_size_safety
 		passed_safety, solution = self.run_safety_test(
-			candidate_solution,debug=debug)
+			candidate_solution,
+			batch_size_safety=batch_size_safety,debug=debug)
 		return passed_safety, solution
 	
-	def run_safety_test(self,candidate_solution,debug=False):
+	def run_safety_test(self,candidate_solution,
+		batch_size_safety=None,debug=False):
 		"""
 		Runs safety test using solution from candidate selection
 		or some other means
@@ -268,7 +271,8 @@ class SeldonianAlgorithm():
 		"""
 			
 		st = self.safety_test()
-		passed_safety = st.run(candidate_solution)
+		passed_safety = st.run(candidate_solution,
+			batch_size_safety=batch_size_safety)
 		if not passed_safety:
 			if debug:
 				print("Failed safety test")

--- a/seldonian/spec.py
+++ b/seldonian/spec.py
@@ -78,7 +78,8 @@ class Spec(object):
 			'hyper_search'  : None,
 			'verbose'       : True,
 		},
-		regularization_hyperparams={}
+		regularization_hyperparams={},
+		batch_size_safety=None,
 		):
 		self.dataset = dataset
 		self.model = model 
@@ -93,6 +94,7 @@ class Spec(object):
 		self.optimizer = optimizer
 		self.optimization_hyperparams = optimization_hyperparams
 		self.regularization_hyperparams = regularization_hyperparams
+		self.batch_size_safety = batch_size_safety
 
 class SupervisedSpec(Spec):
 	""" Specification object for running Supervised learning
@@ -162,6 +164,7 @@ class SupervisedSpec(Spec):
 			'verbose'       : True,
 		},
 		regularization_hyperparams={},
+		batch_size_safety=None,
 		):
 		super().__init__(
 			dataset=dataset,
@@ -176,7 +179,8 @@ class SupervisedSpec(Spec):
 			optimization_technique=optimization_technique,
 			optimizer=optimizer,
 			optimization_hyperparams=optimization_hyperparams,
-			regularization_hyperparams=regularization_hyperparams)
+			regularization_hyperparams=regularization_hyperparams,
+			batch_size_safety=batch_size_safety)
 		self.sub_regime = sub_regime
 
 
@@ -263,6 +267,7 @@ class RLSpec(Spec):
 			'verbose'       : True,
 		},
 		regularization_hyperparams={},
+		batch_size_safety=None,
 		):
 
 		super().__init__(
@@ -278,7 +283,8 @@ class RLSpec(Spec):
 			optimization_technique=optimization_technique,
 			optimizer=optimizer,
 			optimization_hyperparams=optimization_hyperparams,
-			regularization_hyperparams=regularization_hyperparams)
+			regularization_hyperparams=regularization_hyperparams,
+			batch_size_safety=batch_size_safety)
 
 def createSupervisedSpec(
 	dataset,

--- a/seldonian/utils/tutorial_utils.py
+++ b/seldonian/utils/tutorial_utils.py
@@ -117,6 +117,7 @@ def make_synthetic_regression_dataset(
     meta_information['feature_col_names'] = ['feature1']
     meta_information['label_col_names'] = ['label']
     meta_information['sensitive_col_names'] = []
+    meta_information['sub_regime'] = 'regression'
 
     # 3. Make a dataset object
     features = np.expand_dims(X,axis=1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,7 @@ def simulated_regression_dataset_aslists():
         meta_information['feature_col_names'] = ['feature1']
         meta_information['label_col_names'] = ['label']
         meta_information['sensitive_col_names'] = []
+        meta_information['sub_regime'] = sub_regime
 
         # 3. Make a dataset object
         features = [np.expand_dims(X1,axis=1),np.expand_dims(X2,axis=1)]
@@ -176,6 +177,7 @@ def simulated_regression_dataset():
         meta_information['feature_col_names'] = ['feature1']
         meta_information['label_col_names'] = ['label']
         meta_information['sensitive_col_names'] = []
+        meta_information['sub_regime'] = sub_regime
 
         # 3. Make a dataset object
         features = np.expand_dims(X,axis=1)

--- a/tests/test_parse_tree.py
+++ b/tests/test_parse_tree.py
@@ -1364,7 +1364,6 @@ def test_ttest_bound_listdata(simulated_regression_dataset_aslists):
 	assert pt.root.lower == float('-inf') # not computed
 	assert pt.root.upper == pytest.approx(166.0071908)
 
-
 def test_bad_bound_method(simulated_regression_dataset):
 	# dummy data for linear regression
 	np.random.seed(0)

--- a/tests/test_safety_test.py
+++ b/tests/test_safety_test.py
@@ -2,6 +2,7 @@ from seldonian.parse_tree.parse_tree import *
 from seldonian.dataset import *
 from seldonian.safety_test.safety_test import SafetyTest
 from seldonian.models import objectives
+from seldonian.RL.RL_model import RL_model
 from seldonian.utils.tutorial_utils import generate_data
 
 from sklearn.model_selection import train_test_split
@@ -9,16 +10,17 @@ import pytest
 
 ### Begin tests
 
-def test_run_safety_test(simulated_regression_dataset):
+def test_run_safety_test_regression(
+    simulated_regression_dataset):
     
     # One constraint, so one parse tree
     constraint_strs = ['Mean_Squared_Error - 2.0']
     deltas = [0.05]
     frac_data_in_safety=0.6
-
+    numPoints=1000
     (dataset,model,primary_objective,
         parse_trees) = simulated_regression_dataset(
-            constraint_strs,deltas)
+            constraint_strs,deltas,numPoints=numPoints)
 
     features = dataset.features
     labels = dataset.labels
@@ -38,15 +40,28 @@ def test_run_safety_test(simulated_regression_dataset):
     candidate_solution = np.array([20,4])
 
     st = SafetyTest(safety_dataset,model,parse_trees)
+
     passed_safety = st.run(candidate_solution)
     assert passed_safety == False
     
     # A candidate solution that we know should pass,
     candidate_solution = np.array([0,1])
+    # First without batching
     passed_safety = st.run(candidate_solution)
     assert passed_safety == True
+    upper_bound_no_batching = parse_trees[0].root.upper
+    assert upper_bound_no_batching == pytest.approx(
+        -0.947692744102955)
+    # Now with batching
+    passed_safety_batching = st.run(candidate_solution,
+        batch_size_safety=int(round(numPoints/10)))
+    assert passed_safety_batching == True
+    upper_bound_batching = parse_trees[0].root.upper
+    assert upper_bound_batching == pytest.approx(
+        -0.947692744102955)
 
-def test_evaluate_primary_objective(simulated_regression_dataset):
+def test_evaluate_primary_objective_regression(
+    simulated_regression_dataset):
     """ Test evaluating the primary objective 
     using solutions on the safety dataset """ 
     
@@ -83,5 +98,57 @@ def test_evaluate_primary_objective(simulated_regression_dataset):
     solution = np.array([0,1])
     primary_obj_evl = st.evaluate_primary_objective(solution,primary_objective)
     assert primary_obj_evl == pytest.approx(0.94263425)
+
+
+def test_evaluate_primary_objective_RL(
+    RL_gridworld_dataset):
+    """ Test evaluating the primary objective 
+    using solutions on the safety dataset """ 
+    
+    # One constraint, so one parse tree
+    rseed=99
+    np.random.seed(rseed)
+    regime='reinforcement_learning'
+    constraint_strs = ['-0.25 - J_pi_new']
+    deltas = [0.05]
+    
+    parse_trees = make_parse_trees_from_constraints(
+        constraint_strs,
+        deltas,
+        regime=regime,
+        sub_regime='all',
+        columns=[],
+        delta_weight_method='equal')
+    (dataset,policy,
+        env_kwargs,primary_objective) = RL_gridworld_dataset()
+                
+    frac_data_in_safety = 0.6
+
+    # Model
+
+    model = RL_model(policy=policy,env_kwargs=env_kwargs)
+
+    candidate_episodes, safety_episodes = train_test_split(
+            dataset.episodes,
+            test_size=frac_data_in_safety, shuffle=False)
+    
+    safety_dataset = RLDataSet(
+        episodes=safety_episodes,
+        num_datapoints=len(safety_episodes),
+        meta_information=dataset.meta_information)
+
+    # A candidate solution that we know is bad
+    solution = np.zeros((9,4))
+    st = SafetyTest(safety_dataset,model,parse_trees,
+        regime=regime)
+    primary_obj_evl = st.evaluate_primary_objective(
+        solution,primary_objective)
+    print(primary_obj_evl)
+    assert primary_obj_evl == pytest.approx(0.45250228)
+    
+
+
+
+
 
 

--- a/tests/test_seldonian_algorithm.py
+++ b/tests/test_seldonian_algorithm.py
@@ -1816,7 +1816,6 @@ def test_no_initial_solution_provided(gpa_regression_dataset,
 	SA = SeldonianAlgorithm(spec)
 	SA.set_initial_solution()
 	assert np.allclose(SA.initial_solution,np.zeros((10,3)))
-
 	
 """ RL based tests """
 


### PR DESCRIPTION
Adds a backward compatible option to create mini batches for the safety data when running the safety test. 

This is useful when the safety data size is large and passing all of it through the forward pass of the model at once is prohibitive, most likely due to lack of sufficient memory. 

Adds an integer parameter `batch_size_safety` to the base `Spec` object which determines the number of samples that will be passed at a single time through the model. The batching happens before the model forward pass and the batched results are subsequently combined into a single output vecto. The default value, `None`, means that no batching will take place. The result will be identical regardless of the value of `batch_size_safety`

**Note 1:** Can be more performant to batch the safety data even when memory allows for not batching, though I have not thoroughly tested this and I don't understand why this would be the case.  

**Note 2:** In the safety test, the safety data are only passed through the model's forward pass, unlike in candidate selection where this operation where forward and backward passes are made on each step of gradient descent. No optimization is happening in the safety test. This is why the result will be identical regardless of whether safety data are batched are not. 
